### PR TITLE
Add ./python/ to interpreter path and fix console path.

### DIFF
--- a/BukkitConsole/src/com/macuyiko/bukkitconsole/ConnectionThread.java
+++ b/BukkitConsole/src/com/macuyiko/bukkitconsole/ConnectionThread.java
@@ -5,6 +5,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.net.Socket;
+
+import org.python.core.Py;
+import org.python.core.PySystemState;
+import org.python.core.PyString;
 import org.python.util.InteractiveInterpreter;
 
 public class ConnectionThread implements Runnable {
@@ -18,6 +22,11 @@ public class ConnectionThread implements Runnable {
 	public ConnectionThread(Socket socket, SocketServer socketServer) {
 		this.socket = socket;
 		this.server = socketServer;
+		
+		PySystemState sys = Py.getSystemState();
+		sys.path.append(new PyString("."));
+		sys.path.append(new PyString("python/"));
+		
 		this.interpreter = new InteractiveInterpreter();
 		try {
 			this.in = new BufferedReader(new InputStreamReader(socket.getInputStream(), "UTF-8"));

--- a/BukkitConsole/src/com/macuyiko/bukkitconsole/PythonConsole.java
+++ b/BukkitConsole/src/com/macuyiko/bukkitconsole/PythonConsole.java
@@ -7,16 +7,14 @@ import org.python.util.PythonInterpreter;
 
 public class PythonConsole {
 	public PythonConsole() {
-		PySystemState.initialize();
-
-		PythonInterpreter interp = new PythonInterpreter(null,
-				new PySystemState());
-
 		PySystemState sys = Py.getSystemState();
 		sys.path.append(new PyString("."));
 		sys.path.append(new PyString("python/"));
 
+		PythonInterpreter interp = new PythonInterpreter(null, sys);
+
 		String scriptname = "python/console.py";
 		interp.execfile(scriptname);
+		interp.close();
 	}
 }


### PR DESCRIPTION
The existing method wasn't working for me, console.py couldn't import
and neither could the interactive prompt. This Uses the system state
instead of creating a new one.
